### PR TITLE
internal/plugin: implement RDNSS wildcard syntax

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -140,6 +140,9 @@ func TestParse(t *testing.T) {
 			source_lla = true
 			preference = "low"
 
+			  [[interfaces.rdnss]]
+			  servers = ["::"]
+
 			[[interfaces]]
 			name = "eth2"
 			verbose = true
@@ -219,7 +222,13 @@ func TestParse(t *testing.T) {
 						RetransmitTimer: 5 * time.Second,
 						DefaultLifetime: 8 * time.Second,
 						Preference:      ndp.Low,
-						Plugins:         []plugin.Plugin{&plugin.LLA{}},
+						Plugins: []plugin.Plugin{
+							&plugin.RDNSS{
+								Lifetime: 8 * time.Second,
+								Servers:  []netaddr.IP{netaddr.IPv6Unspecified()},
+							},
+							&plugin.LLA{},
+						},
 					},
 					{
 						Name:            "eth2",
@@ -299,7 +308,7 @@ func TestParseDefaults(t *testing.T) {
 		  prefix = "2001:db8:ffff::/64"
 
 		  [[interfaces.rdnss]]
-		  servers = ["2001:db8::1", "2001:db8::2"]
+		  servers = ["::"]
 
 		  [[interfaces.dnssl]]
 		  domain_names = ["foo.example.com"]

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -143,12 +143,18 @@ preference = "medium"
 
   # RDNSS: attaches a NDP Recursive DNS Servers option to the router advertisement.
   [[interfaces.rdnss]]
+  # The DNS servers which should be advertised. Explicit IPv6 addresses may be
+  # specified, but the special :: wildcard will choose a suitable IPv6 address
+  # (preferring Unique Local Addresses, then Global Unicast Addresses, then
+  # Link-Local Addresses) from this interface to serve in the event that the DNS
+  # server resides on the same interface as CoreRAD.
+  servers = ["::"]
+
   # The maximum time these RDNSS addresses may be used for name resolution.
   # An empty string or 0 means these servers should no longer be used.
   # "auto" will compute a sane default. "infinite" means these servers should
   # be used forever.
   lifetime = "auto"
-  servers = ["2001:db8::1", "2001:db8::2"]
 
   # DNSSL: attaches a NDP DNS Search List option to the router advertisement.
   [[interfaces.dnssl]]

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -246,6 +246,8 @@ func parseRDNSS(d rawRDNSS, maxInterval time.Duration) (*plugin.RDNSS, error) {
 	}
 
 	if len(d.Servers) == 0 {
+		// TODO(mdlayher): should this imply the :: wildcard support? If so
+		// consider also implying ::/64 for empty prefix option.
 		return nil, errors.New("must specify one or more DNS server IPv6 addresses")
 	}
 

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -637,6 +637,19 @@ func Test_parseRDNSS(t *testing.T) {
 			},
 			ok: true,
 		},
+		{
+			name: "OK wildcard server",
+			s: `
+			[[interfaces]]
+			  [[interfaces.rdnss]]
+			  servers = ["::"]
+			`,
+			r: &plugin.RDNSS{
+				Lifetime: 20 * time.Minute,
+				Servers:  []netaddr.IP{netaddr.IPv6Unspecified()},
+			},
+			ok: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Credit for this idea comes from https://github.com/radvd-project/radvd/issues/126. I've been configuring automatic DNS servers via my NixOS templating, but this will be even more convenient for cases where CoreRAD and a DNS server are bound to the same interface.