### PR TITLE
allow to specify source LLA's address

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,7 +83,7 @@ type rawInterface struct {
 	RDNSS         []rawRDNSS  `toml:"rdnss"`
 	DNSSL         []rawDNSSL  `toml:"dnssl"`
 	MTU           int         `toml:"mtu"`
-	SourceLLA     *bool       `toml:"source_lla"`
+	SourceLLA     *string     `toml:"source_lla"`
 	CaptivePortal string      `toml:"captive_portal"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,7 @@
 package config_test
 
 import (
+	"net"
 	"strings"
 	"testing"
 	"time"
@@ -129,6 +130,7 @@ func TestParse(t *testing.T) {
 			min_interval = "6m"
 			hop_limit = 64
 			default_lifetime = "auto"
+			source_lla = "auto"
 			mtu = 1500
 			preference = "medium"
 
@@ -161,7 +163,7 @@ func TestParse(t *testing.T) {
 			other_config = true
 			reachable_time = "30s"
 			retransmit_timer = "5s"
-			source_lla = true
+			source_lla = "de:ad:be:ef:de:ad"
 			captive_portal = ""
 			preference = "low"
 
@@ -173,7 +175,7 @@ func TestParse(t *testing.T) {
 			verbose = true
 			hop_limit = 0
 			unicast_only = true
-			source_lla = false
+			source_lla = "none"
 			captive_portal = "http://router/portal"
 			preference = "high"
 
@@ -234,7 +236,9 @@ func TestParse(t *testing.T) {
 								DomainNames: []string{"lan.example.com"},
 							},
 							plugin.NewMTU(1500),
-							&plugin.LLA{},
+							&plugin.LLA{
+								Address: nil,
+							},
 						},
 					},
 					{
@@ -254,7 +258,9 @@ func TestParse(t *testing.T) {
 								Auto:     true,
 								Lifetime: 8 * time.Second,
 							},
-							&plugin.LLA{},
+							&plugin.LLA{
+								Address: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
+							},
 						},
 					},
 					{

--- a/internal/config/plugin_test.go
+++ b/internal/config/plugin_test.go
@@ -720,7 +720,7 @@ func pluginDecode(t *testing.T, s string, ok bool, want plugin.Plugin) {
 
 	// For test purposes, only attach source LLA if explicitly true.
 	if f.Interfaces[0].SourceLLA == nil {
-		v := false
+		v := "none"
 		f.Interfaces[0].SourceLLA = &v
 	}
 

--- a/internal/config/reference.toml
+++ b/internal/config/reference.toml
@@ -79,8 +79,9 @@ default_lifetime = "auto"
 mtu = 0
 
 # AdvSourceLLAddress: attaches a NDP source link-layer address option to the
-# router advertisement. Defaults to true when omitted.
-source_lla = true
+# router advertisement. Specify router MAC address or set to auto to use MAC
+# address of current interface. Defaults to auto when omitted.
+source_lla = "auto"
 
 # Attaches a NDP captive portal option to the router advertisement. Only set
 # when a URI value is present and not an empty string.

--- a/internal/crhttp/handler_test.go
+++ b/internal/crhttp/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -127,7 +128,7 @@ func TestHandlerRoutes(t *testing.T) {
 					DefaultLifetime: 30 * time.Minute,
 					ReachableTime:   12345 * time.Millisecond,
 					Plugins: []plugin.Plugin{
-						&plugin.LLA{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
+						&plugin.LLA{Address: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad}},
 						plugin.NewMTU(1500),
 						&plugin.Prefix{
 							Autonomous:        true,

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -94,19 +94,23 @@ func (d *DNSSL) Apply(ra *ndp.RouterAdvertisement) error {
 }
 
 // LLA configures a NDP Source Link Layer Address option.
-type LLA net.HardwareAddr
+type LLA struct {
+	Address net.HardwareAddr
+}
 
 // Name implements Plugin.
 func (l *LLA) Name() string { return "lla" }
 
 // String implements Plugin.
 func (l *LLA) String() string {
-	return fmt.Sprintf("source link-layer address: %s", net.HardwareAddr(*l))
+	return fmt.Sprintf("source link-layer address: %s", l.Address)
 }
 
 // Prepare implements Plugin.
 func (l *LLA) Prepare(ifi *net.Interface) error {
-	*l = LLA(ifi.HardwareAddr)
+	if l.Address == nil {
+		l.Address = ifi.HardwareAddr
+	}
 	return nil
 }
 
@@ -114,7 +118,7 @@ func (l *LLA) Prepare(ifi *net.Interface) error {
 func (l *LLA) Apply(ra *ndp.RouterAdvertisement) error {
 	ra.Options = append(ra.Options, &ndp.LinkLayerAddress{
 		Direction: ndp.Source,
-		Addr:      net.HardwareAddr(*l),
+		Addr:      l.Address,
 	})
 
 	return nil

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -59,7 +59,7 @@ func TestPluginString(t *testing.T) {
 		},
 		{
 			name: "LLA",
-			p:    &LLA{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad},
+			p:    &LLA{Address: net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad}},
 			s:    "source link-layer address: de:ad:be:ef:de:ad",
 		},
 		{


### PR DESCRIPTION
While this causes a breaking change in the way `source_lla` is configured, it could be an approach to allow for overriding the source link-layer address derived from the dialing interface.