### PR TITLE
RFC: internal/*: support for automatic routes from loopback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.7
-	github.com/jsimonetti/rtnetlink v1.1.0
+	github.com/jsimonetti/rtnetlink v1.1.1
 	github.com/mdlayher/metricslite v0.0.0-20200705182329-f8b577e97896
 	github.com/mdlayher/ndp v0.0.0-20220304194648-de594d7bc183
 	github.com/mdlayher/netlink v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/ebpf v0.8.0 h1:2V6KSg3FRADVU2BMIRemZ0hV+9OM+aAHhZDjQyjJTAs=
-github.com/cilium/ebpf v0.8.0/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/cilium/ebpf v0.8.1 h1:bLSSEbBLqGPXxls55pGr5qWZaTqcmfDJHhou7t254ao=
+github.com/cilium/ebpf v0.8.1/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -134,8 +134,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=
 github.com/josharian/native v1.0.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
-github.com/jsimonetti/rtnetlink v1.1.0 h1:mB3OuXVjAdm3cClDVMWr/cHLmeUGK0XjWERNIppzaZs=
-github.com/jsimonetti/rtnetlink v1.1.0/go.mod h1:5OxELYQq4nwWK2nBvKQWrYZH7VUBZQrCqtPQS01FUgE=
+github.com/jsimonetti/rtnetlink v1.1.1 h1:vVZWilg+F8oIu3vh12C1gEutuSDw+N0yeJZQAzqEMuk=
+github.com/jsimonetti/rtnetlink v1.1.1/go.mod h1:TzDCVOZKUa79z6iXbbXqhtAflVgUKaFkZ21M5tK5tzY=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,6 +142,8 @@ func TestParse(t *testing.T) {
 			  deprecated = true
 
 			  [[interfaces.route]]
+
+			  [[interfaces.route]]
 			  prefix = "2001:db8:ffff::/64"
 
 			  [[interfaces.rdnss]]
@@ -220,6 +222,12 @@ func TestParse(t *testing.T) {
 								ValidLifetime:     24 * time.Hour,
 								PreferredLifetime: 4 * time.Hour,
 								Deprecated:        true,
+							},
+							&plugin.Route{
+								Auto:       true,
+								Prefix:     netaddr.MustParseIPPrefix("::/0"),
+								Preference: ndp.Medium,
+								Lifetime:   24 * time.Hour,
 							},
 							&plugin.Route{
 								Prefix:     netaddr.MustParseIPPrefix("2001:db8:ffff::/64"),

--- a/internal/config/reference.toml
+++ b/internal/config/reference.toml
@@ -145,7 +145,21 @@ preference = "medium"
   [[interfaces.prefix]]
   prefix = "2001:db8::/64"
 
-  # Route: attaches a NDP Route Information option to the router advertisement.
+  # Route: attaches an NDP Route Information option to the router advertisement.
+  [[interfaces.route]]
+  # Serve Route Information options for each IPv6 destination route configured
+  # on system loopback interfaces, meaning this router owns that route and can
+  # be the authority on how traffic is routed to that prefix. This is a typical
+  # configuration for DHCPv6 Prefix Delegation; for example, an ISP router
+  # delegates a /48 prefix on a WAN interface. The router will configure a /48
+  # unreachable route on loopback (as it owns the entire delegated prefix), but
+  # it can advertise more specific /64 prefixes on each LAN.
+  #
+  # Only ::/0 is allowed for this special case. If prefix is an empty string or
+  # omitted, "::/0" is assumed.
+  prefix = "::/0"
+
+  # Alternatively, serve an explicit IPv6 route.
   [[interfaces.route]]
   prefix = "2001:db8:ffff::/64"
 

--- a/internal/system/addresser.go
+++ b/internal/system/addresser.go
@@ -16,13 +16,18 @@ package system
 import (
 	"net"
 
+	"github.com/mdlayher/ndp"
 	"inet.af/netaddr"
 )
 
-// An Addresser is a type that can fetch IP address information from the
-// operating system.
+// An Addresser is a type that can fetch IP address and route information from
+// the operating system.
+//
+// TODO(mdlayher): this name is a bit awkward with the inclusion of Routes.
+// Reconsider.
 type Addresser interface {
 	AddressesByIndex(index int) ([]IP, error)
+	LoopbackRoutes() ([]Route, error)
 }
 
 // An IP is an IP address and its associated operating system-specific metadata.
@@ -39,6 +44,19 @@ type IP struct {
 	// Reports whether the operating system treats this address as valid
 	// forever, as is the case for static addresses.
 	ValidForever bool
+}
+
+// A Route is an destination route and its associated operating system-specific
+// metadata.
+type Route struct {
+	// A destination route for an interface.
+	Prefix netaddr.IPPrefix
+
+	// The index of the network interface which contains this route.
+	Index int
+
+	// The NDP preference value for a particular route.
+	Preference ndp.Preference
 }
 
 // A netAddresser is a generic Addresser which uses package net functions.
@@ -79,4 +97,10 @@ func (*netAddresser) AddressesByIndex(index int) ([]IP, error) {
 	}
 
 	return ips, nil
+}
+
+// LoopbackRoutes implements Addresser.
+func (*netAddresser) LoopbackRoutes() ([]Route, error) {
+	// No cross-platform implementation for fetching routes. Do nothing.
+	return nil, nil
 }

--- a/internal/system/addresser_test.go
+++ b/internal/system/addresser_test.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mdlayher/corerad/internal/system"
+	"golang.org/x/net/nettest"
 	"inet.af/netaddr"
 )
 
-func TestIntegrationAddresser(t *testing.T) {
+func TestIntegrationAddresserAddresses(t *testing.T) {
 	ifis, err := net.Interfaces()
 	if err != nil {
 		t.Fatalf("failed to get interfaces: %v", err)
@@ -101,6 +102,23 @@ func TestIntegrationAddresser(t *testing.T) {
 				t.Fatalf("interface %q address %q was not found", ifi.Name, addr)
 			}
 		}
+	}
+}
+
+func TestIntegrationAddresserLoopbackRoutes(t *testing.T) {
+	lo, err := nettest.LoopbackInterface()
+	if err != nil {
+		t.Skipf("skipping, found no loopback network interface: %v", err)
+	}
+
+	routes, err := system.NewAddresser().LoopbackRoutes()
+	if err != nil {
+		t.Fatalf("failed to get loopback routes: %v", err)
+	}
+
+	t.Logf("loopback: %s, index: %d, flags: %s", lo.Name, lo.Index, lo.Flags)
+	for _, r := range routes {
+		t.Logf("  - %s: index %d, preference: %s", r.Prefix, r.Index, r.Preference)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

I've traveled a bit recently and noticed some ATT DHCPv6-PD setups are advertising:

- prefix /64 for SLAAC
- route information for the covering /60

This makes sense in the event that multiple routers may be present on a network: the router "owns" the covering /60 and anything in that /60 should be sent to that router. An unreachable route for the /60 is set on router's lo and then longer /64 routes are added for each LAN.

Consider a hypothetical /48 DHCPv6-PD setup may configure the following addresses and routes on cradveth0 (a LAN interface) and lo, the loopback:

```
$ ip -6 a s dev cradveth0
4: cradveth0@cradveth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet6 2001:db8::1/64 scope global 
       valid_lft forever preferred_lft forever
    inet6 fd38:4ad5:6ad6::1/64 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::d02b:fdff:fe71:97c9/64 scope link 
       valid_lft forever preferred_lft forever
```
```
$ ip -6 r s dev lo
::1 proto kernel metric 256 pref medium
unreachable 2001:db8::/48 metric 1024 pref medium
unreachable 2001:db8::/32 metric 1024 pref medium
unreachable fd38:4ad5:6ad6::/48 metric 1024 pref medium
```

For demonstration, I've also added an overlapping /32 for the delegated prefix and a ULA /48.

Given the following configuration:
```toml
# CoreRAD development (n/a) configuration file
[[interfaces]]
name = "cradveth0"
advertise = true
  [[interfaces.prefix]]
  [[interfaces.route]]
```

CoreRAD will start up as follows:
```
$ sudo ./corerad 
CoreRAD development (n/a) starting with configuration file "corerad.toml"
cradveth0: "prefix": ::/64 [fd38:4ad5:6ad6::/64] [on-link, autonomous], preferred: 4h0m0s, valid: 24h0m0s
cradveth0: "route": ::/0 [2001:db8::/32, fd38:4ad5:6ad6::/48], preference: Medium, lifetime: 24h0m0s
cradveth0: "lla": source link-layer address: d2:2b:fd:71:97:c9
cradveth0: initialized, advertising from fe80::d02b:fdff:fe71:97c9
```

Producing the following router advertisement:
```
$ ndp -i cradveth1 rs
ndp> interface: cradveth1, link-layer address: 2e:81:cb:78:01:ad, IPv6 address: fe80::2c81:cbff:fe78:1ad
ndp rs> router solicitation:
  - source link-layer address: 2e:81:cb:78:01:ad

ndp rs> router advertisement from: fe80::d02b:fdff:fe71:97c9:
  - hop limit:        64
  - preference:       Medium
  - router lifetime:  30m0s
  - options:
    - prefix information: 2001:db8::/64, flags: [on-link, autonomous], valid: 24h0m0s, preferred: 4h0m0s
    - prefix information: fd38:4ad5:6ad6::/64, flags: [on-link, autonomous], valid: 24h0m0s, preferred: 4h0m0s
    - route information: 2001:db8::/32, preference: Medium, lifetime: 24h0m0s
    - route information: fd38:4ad5:6ad6::/48, preference: Medium, lifetime: 24h0m0s
    - source link-layer address: d2:2b:fd:71:97:c9
```

This seems like a useful behavior to me, but there are some questions here:

- What happens if a user is using multiple routing tables? Right now we only check for automatic routes from "main", table 254. Do we tell the user they're on their own?
- Would it be useful to support `::/48` or similar instead of just `::/0`, meaning "any route /48 or longer?". This would drop the covering /32.
- Should we only support this behavior for routes with type unreachable/blackhole? Right now we ignore the type and assume any route configured on a loopback should be redistributed via NDP RA.

Feedback very welcome! This is something I want to deploy on my own LAN but I am also afraid of implementing something that is subtly incorrect.