### PR TITLE
Prometheus documentation: default to listening on all addresses.

### DIFF
--- a/internal/config/reference.toml
+++ b/internal/config/reference.toml
@@ -214,6 +214,10 @@ preference = "medium"
 #
 # Warning: do not expose pprof on an untrusted network!
 [debug]
-address = "localhost:9430"
+# Address syntax follows net.Listen semantics.
+# In particular, while you can pass a hostname (localhost:9430) or IP address,
+# if you only specify a port, the server will listen on all available unicast
+# and anycast UP addresses of the local system.
+address = ":9430"
 prometheus = false
 pprof = false

--- a/website/content/operation.md
+++ b/website/content/operation.md
@@ -91,7 +91,7 @@ reach the server.
 ```toml
 # Optional: enable Prometheus metrics.
 [debug]
-address = "localhost:9430"
+address = ":9430"
 prometheus = true
 # WARNING: do not expose pprof on a public network!
 pprof = false


### PR DESCRIPTION
`localhost:9430` picks one particular IP/interface, which can be quite
confusing on systems with many interfaces or addresses. It likely makes
most sense to default to listening on all addresses so this does not
cause confusion.

(And we expect users to have adequate firewalling to prevent access from
WAN if relevant)

---

Some additional background: I spent more time than I'm comfortable admitting, trying to debug why Prometheus running in Docker container could not reach corerad on the host. From Docker, the host is addressed as `172.x.x.x`, an address that corerad does not bind to if one uses `address = "localhost:9430"`.

Thanks!